### PR TITLE
Add local model support (Ollama, LM Studio, llama.cpp, Claude Proxy)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,8 @@ export_presets.cfg
 .vscode/
 *.suo
 *.user
+
+# Claude Code (local only)
+CLAUDE.md
+.claude/
+.mcp.json

--- a/CLAUDE_PROXY_SETUP.md
+++ b/CLAUDE_PROXY_SETUP.md
@@ -1,0 +1,105 @@
+# Claude Proxy Setup
+
+Use GodotAI with your **Claude Pro or Max subscription** — no API key or separate billing required.
+
+Claude Pro/Max subscribers get access to the Claude Code CLI. The bundled proxy script translates GodotAI's requests into CLI calls, so you can use your existing subscription directly.
+
+---
+
+## Prerequisites
+
+- **Claude Code CLI** installed and signed in ([claude.ai/code](https://claude.ai/code))
+  - Verify: `claude --version` should print a version number
+  - If not signed in: run `claude` once and follow the login prompts
+- **Python 3.8+** (pre-installed on macOS; available on all platforms)
+
+---
+
+## 1. Start the Proxy
+
+### From Godot (recommended)
+
+1. Open the **GodotAI Settings** dialog (gear icon in the panel).
+2. Switch to the **Local** tab.
+3. Select **Claude Proxy** from the **Server Preset** dropdown.
+4. Click the **Start** button that appears next to "Built-in Proxy".
+5. The status label turns green when the proxy is running.
+
+Click **Stop** to shut it down. The proxy is also stopped automatically when the plugin is disabled or the editor closes.
+
+### From a terminal (alternative)
+
+If you need custom options (e.g. a different port), start the proxy manually:
+
+```bash
+python3 tools/claude_proxy.py
+```
+
+The proxy runs at `http://localhost:8082` by default. Leave this terminal open while using GodotAI.
+
+**Options:**
+
+```bash
+python3 tools/claude_proxy.py --port 8082    # custom port
+python3 tools/claude_proxy.py --verbose      # log requests to stderr
+```
+
+---
+
+## 2. Verify It Works
+
+```bash
+curl http://localhost:8082/v1/models
+```
+
+You should see a JSON list of Claude models. If you see an error, check the proxy terminal output.
+
+---
+
+## 3. Configure GodotAI
+
+1. Open the **GodotAI Settings** dialog (gear icon in the panel).
+2. Switch to the **Local** tab.
+3. Select **Claude Proxy** from the **Server Preset** dropdown.
+   - Endpoint URL auto-fills to `http://localhost:8082/v1`.
+4. Click **Refresh** to load the model list.
+5. Select a model (e.g., `sonnet` or `claude-sonnet-4-6`).
+6. Leave **API Key** empty.
+7. Click **Save**.
+
+---
+
+## 4. Available Models
+
+| Alias | Full name |
+|-------|-----------|
+| `sonnet` | claude-sonnet-4-6 |
+| `opus` | claude-opus-4-6 |
+| `haiku` | claude-haiku-4-5 |
+
+Use aliases for convenience or full model IDs for precision.
+
+---
+
+## Alternative: Third-Party Proxy
+
+If you prefer not to run the bundled script, [`claude-code-proxy`](https://github.com/PallavAg/claude-code-proxy) is a popular npm alternative:
+
+```bash
+npx claude-code-proxy
+```
+
+It runs on port `8082` by default and is compatible with the Claude Proxy preset.
+
+---
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| `Connection refused` | Proxy is not running — start it with `python3 tools/claude_proxy.py` |
+| `'claude' command not found` | Install Claude Code from [claude.ai/code](https://claude.ai/code) |
+| `Not logged in` | Run `claude` in a terminal and complete the login flow |
+| Model list empty | Click **Refresh** in settings, or check proxy terminal for errors |
+| Slow first response | Normal — the Claude CLI has a short startup time on the first request |
+| Port already in use | Use `--port 8083` (and update the endpoint URL in settings accordingly) |

--- a/OLLAMA_SETUP.md
+++ b/OLLAMA_SETUP.md
@@ -1,0 +1,87 @@
+# Ollama Setup for Local Model Testing
+
+## 1. Install Ollama
+
+### macOS
+```bash
+brew install ollama
+```
+Or download the installer from [ollama.com](https://ollama.com/download).
+
+## 2. Start the Ollama Server
+
+```bash
+ollama serve
+```
+
+Ollama runs at `http://localhost:11434` by default. Leave this terminal open, or run it as a background service:
+
+```bash
+# Run in background (macOS launchd — starts automatically on login after brew install)
+brew services start ollama
+```
+
+## 3. Pull a Model
+
+Choose a model based on your hardware:
+
+| Model | Size | RAM Required | Notes |
+|-------|------|-------------|-------|
+| `llama3.2:3b` | ~2 GB | 4 GB | Fastest, good for testing |
+| `llama3.2` | ~5 GB | 8 GB | Balanced |
+| `llama3.1:8b` | ~5 GB | 8 GB | Strong general purpose |
+| `mistral` | ~4 GB | 8 GB | Good for code |
+| `codellama:7b` | ~4 GB | 8 GB | Code-focused |
+| `llama3.1:70b` | ~40 GB | 64 GB | Best quality, needs high-end GPU |
+
+```bash
+# Recommended for testing on a typical machine
+ollama pull llama3.2:3b
+
+# Or for better quality
+ollama pull llama3.2
+```
+
+## 4. Verify the Model Works
+
+```bash
+ollama run llama3.2:3b "Hello, are you working?"
+```
+
+## 5. Configure GodotAI Plugin
+
+In the GodotAI settings dialog, use these values for the **OpenAI Compatible** provider:
+
+- **Base URL:** `http://localhost:11434/v1`
+- **API Key:** `ollama` (any non-empty string works)
+- **Model:** `llama3.2:3b` (or whatever model you pulled)
+
+> Ollama exposes an OpenAI-compatible `/v1/chat/completions` endpoint, so the OpenAI Compatible provider works directly.
+
+## 6. List Installed Models
+
+```bash
+ollama list
+```
+
+## 7. Remove a Model
+
+```bash
+ollama rm llama3.2:3b
+```
+
+## Troubleshooting
+
+- **Connection refused:** Make sure `ollama serve` is running.
+- **Model not found:** Run `ollama pull <model-name>` first.
+- **Slow responses:** Use a smaller model (e.g., `3b` instead of `8b`).
+- **Out of memory:** Switch to a smaller model or enable GPU acceleration if available.
+
+## Useful Commands
+
+```bash
+ollama list          # Show downloaded models
+ollama ps            # Show running models
+ollama serve         # Start server manually
+ollama run <model>   # Interactive chat in terminal
+```

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # GodotAI
 
-An AI coding assistant built directly into the Godot editor. Chat with Claude, ChatGPT, or any OpenRouter model without leaving Godot get code suggestions, ask questions about your project, and insert AI-generated code straight into your scripts.
+An AI coding assistant built directly into the Godot editor. Chat with Claude, ChatGPT, any OpenRouter model, or local models via Ollama — without leaving Godot. Already have a **Claude Pro or Max subscription**? The built-in proxy lets you use it directly with no API billing. Prefer fully offline? Connect to Ollama, LM Studio, or any local model — no API key or internet required.
 
 ## Features
 
 - **Chat panel** docked at the bottom of the Godot editor
-- **Multi-provider:** Anthropic (Claude), OpenAI (ChatGPT), OpenRouter (500+ models)
+- **Multi-provider:** Anthropic (Claude), OpenAI (ChatGPT), OpenRouter (500+ models), Local (Ollama, LM Studio, llama.cpp)
+- **Built-in Claude Proxy** — use your Claude Pro or Max subscription directly; start/stop from within Godot with no API key or separate billing
+- **Local model support** — run fully offline with Ollama, LM Studio, llama.cpp, or any OpenAI-compatible server; no API key or internet required
 - **Streaming responses** — text appears as it is generated, not all at once
 - **Markdown rendering** with syntax-highlighted code blocks
 - **Insert at Cursor** — click any code block to insert it into the active script
@@ -27,6 +29,7 @@ An AI coding assistant built directly into the Godot editor. Chat with Claude, C
   - [Anthropic](https://console.anthropic.com/) (Claude models)
   - [OpenAI](https://platform.openai.com/) (GPT models)
   - [OpenRouter](https://openrouter.ai/) (500+ models from many providers)
+  - **None** — if using a local server (Ollama, LM Studio, llama.cpp, etc.) or Claude Proxy
 
 ## Installation
 
@@ -48,8 +51,8 @@ An AI coding assistant built directly into the Godot editor. Chat with Claude, C
 
 1. After enabling the plugin, a **GodotAI** panel appears at the bottom of the editor.
 2. Click the **Settings** button (gear icon) in the panel.
-3. Select your provider (Anthropic, OpenAI, or OpenRouter).
-4. Enter your **API key** for that provider.
+3. Select your provider (Anthropic, OpenAI, OpenRouter, or Local).
+4. Enter your **API key** for that provider. (Not required for local servers or Claude Proxy.)
 5. Choose a model (or type a custom model ID).
 6. Click **Save**.
 7. Start chatting.
@@ -58,9 +61,40 @@ An AI coding assistant built directly into the Godot editor. Chat with Claude, C
 
 | Provider   | Models                              | Notes                              |
 |------------|-------------------------------------|------------------------------------|
-| Anthropic  | Claude 3.5 Sonnet, Claude 3 Haiku, etc. | Best for code; recommended default |
+| Anthropic  | Claude Sonnet 4, Claude Haiku 4, etc. | Best for code; recommended default |
 | OpenAI     | GPT-4o, GPT-4 Turbo, GPT-3.5, etc. | —                                  |
 | OpenRouter | 500+ models                         | Model list fetched live from API   |
+| Local      | Ollama, LM Studio, llama.cpp, Claude Proxy | Any OpenAI-compatible server; see [OLLAMA_SETUP.md](./OLLAMA_SETUP.md) or [CLAUDE_PROXY_SETUP.md](./CLAUDE_PROXY_SETUP.md) |
+
+## Free Options: Claude Proxy & Local Models
+
+GodotAI can run without any API key or subscription cost using two built-in options.
+
+### Claude Proxy — Use Your Claude Subscription
+
+If you have a **Claude Pro or Max subscription**, you already have access to the Claude Code CLI. The bundled proxy bridges GodotAI to your CLI session, giving you Claude Sonnet, Opus, and Haiku with no per-token billing.
+
+**Quick start:**
+1. Install [Claude Code](https://claude.ai/code) and sign in (`claude --version` to verify).
+2. Open **Settings → Local tab** in the GodotAI panel.
+3. Select **Claude Proxy** from the Server Preset dropdown.
+4. Click **Start** — the proxy launches in the background and the status turns green.
+5. Pick a model and start chatting.
+
+For full setup details and troubleshooting, see [CLAUDE_PROXY_SETUP.md](./CLAUDE_PROXY_SETUP.md).
+
+### Local Models — Fully Offline & Free
+
+Run open-source models on your own hardware with [Ollama](https://ollama.com), [LM Studio](https://lmstudio.ai), [llama.cpp](https://github.com/ggml-org/llama.cpp), or any OpenAI-compatible server. No API key, no internet, no cost.
+
+**Quick start with Ollama:**
+1. Install Ollama and pull a model: `ollama pull llama3.2`
+2. Open **Settings → Local tab** in the GodotAI panel.
+3. Select **Ollama** from the Server Preset dropdown.
+4. Click **Refresh** — available models load automatically.
+5. Pick a model and start chatting.
+
+For model recommendations and full setup, see [OLLAMA_SETUP.md](./OLLAMA_SETUP.md).
 
 ## Keyboard Shortcuts
 
@@ -74,6 +108,8 @@ Default shortcuts (configurable in Settings → Shortcuts):
 
 ## Usage Tips
 
+- **Claude Proxy:** If you have a Claude Pro or Max subscription, you can use it directly via the bundled Python proxy — no separate API billing required. Select **Claude Proxy** in the Local tab of Settings, then click **Start** to launch it without leaving Godot. See [CLAUDE_PROXY_SETUP.md](./CLAUDE_PROXY_SETUP.md) for full setup details.
+- **Local Models:** Install Ollama and pull a model (`ollama pull llama3.2`), then select the **Ollama** preset in the Local tab — GodotAI auto-detects available models. See [OLLAMA_SETUP.md](./OLLAMA_SETUP.md) for other local server options.
 - **Send selected code:** Select code in a script editor, then press `Ctrl+Shift+/` to paste it into the chat input automatically.
 - **Insert at Cursor:** In any AI response, hover over a code block and click the **Insert** button to paste the code into the script currently open in the editor.
 - **Context:** GodotAI automatically includes your active script content and scene tree structure in the system prompt so the AI understands your project.

--- a/addons/godot_ai/config/settings.gd
+++ b/addons/godot_ai/config/settings.gd
@@ -11,6 +11,7 @@ const SECTION_GENERAL := "general"
 const SECTION_ANTHROPIC := "anthropic"
 const SECTION_OPENAI := "openai"
 const SECTION_OPENROUTER := "openrouter"
+const SECTION_LOCAL := "local"
 const SECTION_SHORTCUTS := "shortcuts"
 const SECTION_CUSTOM_MODELS := "custom_models"
 
@@ -46,6 +47,14 @@ var openrouter_model: String = "anthropic/claude-opus-4"
 var openrouter_temperature: float = 0.7
 var openrouter_max_tokens: int = 4096
 
+# Local (Ollama / LM Studio / llama.cpp / custom OpenAI-compatible server)
+var local_endpoint_url: String = "http://localhost:11434/v1"
+var local_api_key: String = ""
+var local_model: String = "llama3.2"
+var local_temperature: float = 0.7
+var local_max_tokens: int = 4096
+var local_server_preset: String = "ollama"
+
 ## Load settings from disk. Missing keys fall back to defaults, numeric values
 ## are clamped to valid ranges, and unknown provider names reset to "Anthropic".
 func load() -> void:
@@ -55,7 +64,7 @@ func load() -> void:
 		return
 
 	var loaded_provider: String = _config.get_value(SECTION_GENERAL, "active_provider", active_provider)
-	active_provider = loaded_provider if loaded_provider in ["anthropic", "openai", "openrouter"] else "anthropic"
+	active_provider = loaded_provider if loaded_provider in ["anthropic", "openai", "openrouter", "local"] else "anthropic"
 	font_size = clampi(int(_config.get_value(SECTION_GENERAL, "font_size", 28)), 10, 48)
 
 	anthropic_api_key = _config.get_value(SECTION_ANTHROPIC, "api_key", "")
@@ -73,12 +82,19 @@ func load() -> void:
 	openrouter_temperature = clampf(float(_config.get_value(SECTION_OPENROUTER, "temperature", openrouter_temperature)), 0.0, 2.0)
 	openrouter_max_tokens = clampi(int(_config.get_value(SECTION_OPENROUTER, "max_tokens", openrouter_max_tokens)), 1, 65536)
 
+	local_endpoint_url = _config.get_value(SECTION_LOCAL, "endpoint_url", local_endpoint_url)
+	local_api_key = _config.get_value(SECTION_LOCAL, "api_key", "")
+	local_model = _config.get_value(SECTION_LOCAL, "model", local_model)
+	local_temperature = clampf(float(_config.get_value(SECTION_LOCAL, "temperature", local_temperature)), 0.0, 2.0)
+	local_max_tokens = clampi(int(_config.get_value(SECTION_LOCAL, "max_tokens", local_max_tokens)), 1, 65536)
+	local_server_preset = _config.get_value(SECTION_LOCAL, "server_preset", local_server_preset)
+
 	shortcut_focus_chat = _config.get_value(SECTION_SHORTCUTS, "focus_chat", "Ctrl+/")
 	shortcut_send_code = _config.get_value(SECTION_SHORTCUTS, "send_code", "Ctrl+Shift+/")
 	shortcut_send_message = _config.get_value(SECTION_SHORTCUTS, "send_message", "Ctrl+Enter")
 
 	custom_models = {}
-	for key in ["anthropic", "openai", "openrouter"]:
+	for key in ["anthropic", "openai", "openrouter", "local"]:
 		var saved = _config.get_value(SECTION_CUSTOM_MODELS, key, [])
 		if saved is Array and not saved.is_empty():
 			custom_models[key] = saved
@@ -104,11 +120,18 @@ func save() -> void:
 	_config.set_value(SECTION_OPENROUTER, "temperature", openrouter_temperature)
 	_config.set_value(SECTION_OPENROUTER, "max_tokens", openrouter_max_tokens)
 
+	_config.set_value(SECTION_LOCAL, "endpoint_url", local_endpoint_url)
+	_config.set_value(SECTION_LOCAL, "api_key", local_api_key)
+	_config.set_value(SECTION_LOCAL, "model", local_model)
+	_config.set_value(SECTION_LOCAL, "temperature", local_temperature)
+	_config.set_value(SECTION_LOCAL, "max_tokens", local_max_tokens)
+	_config.set_value(SECTION_LOCAL, "server_preset", local_server_preset)
+
 	_config.set_value(SECTION_SHORTCUTS, "focus_chat", shortcut_focus_chat)
 	_config.set_value(SECTION_SHORTCUTS, "send_code", shortcut_send_code)
 	_config.set_value(SECTION_SHORTCUTS, "send_message", shortcut_send_message)
 
-	for key in ["anthropic", "openai", "openrouter"]:
+	for key in ["anthropic", "openai", "openrouter", "local"]:
 		if custom_models.has(key) and not custom_models[key].is_empty():
 			_config.set_value(SECTION_CUSTOM_MODELS, key, custom_models[key])
 		else:

--- a/addons/godot_ai/config/settings_dialog.gd
+++ b/addons/godot_ai/config/settings_dialog.gd
@@ -3,7 +3,7 @@ class_name AISettingsDialog
 extends AcceptDialog
 
 ## Settings UI for GodotAI plugin.
-## Provider tabs: Anthropic, OpenAI, OpenRouter.
+## Provider tabs: Anthropic, OpenAI, OpenRouter, Local.
 ## Shows API key fields, model dropdowns, temperature sliders.
 
 signal settings_saved(settings: AISettings)
@@ -53,9 +53,37 @@ var _openrouter_temp_slider: HSlider
 var _openrouter_temp_label: Label
 var _openrouter_tokens_spin: SpinBox
 
+# Local tab
+var _local_endpoint_field: LineEdit
+var _local_key_field: LineEdit
+var _local_model_option: OptionButton
+var _local_refresh_btn: Button
+var _local_temp_slider: HSlider
+var _local_temp_label: Label
+var _local_tokens_spin: SpinBox
+var _local_status_label: Label
+var _local_preset_option: OptionButton
+var _proxy_control_row: HBoxContainer
+var _proxy_toggle_btn: Button
+var _proxy_status_label: Label
+
+var _start_proxy_callable: Callable
+var _stop_proxy_callable: Callable
+var _is_proxy_running_callable: Callable
+
+const LOCAL_PRESETS := {
+	"ollama": "http://localhost:11434/v1",
+	"lm_studio": "http://localhost:1234/v1",
+	"llamacpp": "http://localhost:8080/v1",
+	"claude_proxy": "http://localhost:8082/v1",
+	"custom": "",
+}
+const LOCAL_PRESET_LABELS: Array[String] = ["Ollama", "LM Studio", "llama.cpp", "Claude Proxy", "Custom"]
+const LOCAL_PRESET_KEYS: Array[String] = ["ollama", "lm_studio", "llamacpp", "claude_proxy", "custom"]
+
 func _ready() -> void:
 	title = "GodotAI Settings"
-	min_size = Vector2i(820, 720)
+	min_size = Vector2i(920, 720)
 	get_ok_button().text = "Save"
 	add_cancel_button("Cancel")
 	confirmed.connect(_on_save)
@@ -65,6 +93,13 @@ func _ready() -> void:
 ## Call once after creating the dialog to give it access to provider model lists.
 func setup_provider_manager(pm: ProviderManager) -> void:
 	_provider_manager = pm
+	_provider_manager.models_fetch_failed.connect(_on_models_fetch_failed)
+
+## Pass callables from plugin.gd to allow starting/stopping the built-in Claude proxy.
+func set_proxy_controls(start_fn: Callable, stop_fn: Callable, is_running_fn: Callable) -> void:
+	_start_proxy_callable = start_fn
+	_stop_proxy_callable = stop_fn
+	_is_proxy_running_callable = is_running_fn
 
 ## Populate the dialog from the given settings and show it.
 ## Also triggers model re-fetch if a provider has an API key but no cached models.
@@ -92,6 +127,7 @@ func _build_ui() -> void:
 	_provider_option.add_item("Anthropic (Claude)", 0)
 	_provider_option.add_item("OpenAI (ChatGPT)", 1)
 	_provider_option.add_item("OpenRouter", 2)
+	_provider_option.add_item("Local (Ollama / LM Studio)", 3)
 	_provider_option.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	_provider_option.item_selected.connect(_on_provider_option_selected)
 	provider_row.add_child(_provider_option)
@@ -108,6 +144,7 @@ func _build_ui() -> void:
 	_tabs.add_child(_build_anthropic_tab())
 	_tabs.add_child(_build_openai_tab())
 	_tabs.add_child(_build_openrouter_tab())
+	_tabs.add_child(_build_local_tab())
 
 func _build_general_tab() -> Control:
 	var container := VBoxContainer.new()
@@ -214,6 +251,87 @@ func _build_openrouter_tab() -> Control:
 
 	var hint := Label.new()
 	hint.text = "Browse models at openrouter.ai/models"
+	hint.add_theme_color_override("font_color", Color(0.6, 0.6, 0.6))
+	container.add_child(hint)
+
+	return container
+
+func _build_local_tab() -> Control:
+	var container := VBoxContainer.new()
+	container.name = "Local"
+	container.add_theme_constant_override("separation", 8)
+
+	# Server Preset
+	var preset_row := HBoxContainer.new()
+	container.add_child(preset_row)
+	var preset_lbl := Label.new()
+	preset_lbl.text = "Server Preset:"
+	preset_lbl.custom_minimum_size.x = 140
+	preset_row.add_child(preset_lbl)
+	_local_preset_option = OptionButton.new()
+	for label in LOCAL_PRESET_LABELS:
+		_local_preset_option.add_item(label)
+	_local_preset_option.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_local_preset_option.item_selected.connect(_on_local_preset_selected)
+	preset_row.add_child(_local_preset_option)
+
+	# Built-in proxy start/stop (only shown for Claude Proxy preset)
+	_proxy_control_row = HBoxContainer.new()
+	container.add_child(_proxy_control_row)
+	var proxy_lbl := Label.new()
+	proxy_lbl.text = "Built-in Proxy:"
+	proxy_lbl.custom_minimum_size.x = 140
+	_proxy_control_row.add_child(proxy_lbl)
+	_proxy_toggle_btn = Button.new()
+	_proxy_toggle_btn.text = "Start Proxy"
+	_proxy_toggle_btn.pressed.connect(_on_proxy_toggle_pressed)
+	_proxy_control_row.add_child(_proxy_toggle_btn)
+	_proxy_status_label = Label.new()
+	_proxy_status_label.text = "Stopped"
+	_proxy_status_label.add_theme_color_override("font_color", Color(0.6, 0.6, 0.6))
+	_proxy_status_label.custom_minimum_size.x = 120
+	_proxy_control_row.add_child(_proxy_status_label)
+	_proxy_control_row.visible = false
+
+	# Endpoint URL
+	var url_row := HBoxContainer.new()
+	container.add_child(url_row)
+	var url_lbl := Label.new()
+	url_lbl.text = "Endpoint URL:"
+	url_lbl.custom_minimum_size.x = 140
+	url_row.add_child(url_lbl)
+	_local_endpoint_field = LineEdit.new()
+	_local_endpoint_field.placeholder_text = "http://localhost:11434/v1"
+	_local_endpoint_field.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	url_row.add_child(_local_endpoint_field)
+	_local_status_label = Label.new()
+	_local_status_label.custom_minimum_size.x = 100
+	url_row.add_child(_local_status_label)
+
+	# API key (optional)
+	_local_key_field = _add_key_row(container, "API Key (optional):")
+	_local_key_field.placeholder_text = "Leave empty for Ollama"
+
+	# Model dropdown with refresh
+	_local_model_option = _add_model_dropdown(container, "Model:", [])
+	_local_refresh_btn = Button.new()
+	_local_refresh_btn.text = "Refresh"
+	_local_refresh_btn.pressed.connect(func():
+		var local := _provider_manager.get_provider("local") if _provider_manager else null
+		if local:
+			local.clear_model_cache()
+		_start_model_fetch("local")
+	)
+	_local_model_option.get_parent().add_child(_local_refresh_btn)
+
+	var temp_r := _add_temperature_row(container, "Temperature:",
+		func(v): _local_temp_label.text = "%.2f" % v)
+	_local_temp_slider = temp_r.slider
+	_local_temp_label = temp_r.label
+	_local_tokens_spin = _add_spinbox_row(container, "Max Tokens:", 1, 65536, 4096)
+
+	var hint := Label.new()
+	hint.text = "Works with Ollama, LM Studio, llama.cpp, or any OpenAI-compatible server."
 	hint.add_theme_color_override("font_color", Color(0.6, 0.6, 0.6))
 	container.add_child(hint)
 
@@ -362,6 +480,9 @@ func _auto_fetch_models() -> void:
 	var openai := _provider_manager.get_provider("openai")
 	if openai and openai.is_configured() and not openai.has_cached_models():
 		_start_model_fetch("openai")
+	var local := _provider_manager.get_provider("local")
+	if local and local.is_configured() and not local.has_cached_models():
+		_start_model_fetch("local")
 
 ## Start an async model fetch: delegate to the provider, connect a one-shot
 ## signal for the result, and show "Loading..." on the refresh button.
@@ -371,9 +492,19 @@ func _start_model_fetch(provider_key: String) -> void:
 	var provider := _provider_manager.get_provider(provider_key)
 	if not provider or provider.is_fetching_models():
 		return
-	var btn: Button = _anthropic_refresh_btn if provider_key == "anthropic" else _openai_refresh_btn
+	var btn: Button
+	match provider_key:
+		"anthropic": btn = _anthropic_refresh_btn
+		"openai": btn = _openai_refresh_btn
+		"local": btn = _local_refresh_btn
+		_: return
+	if not btn:
+		return
 	btn.text = "Loading..."
 	btn.disabled = true
+	if provider_key == "local" and _local_status_label:
+		_local_status_label.text = "Checking..."
+		_local_status_label.add_theme_color_override("font_color", Color(0.6, 0.6, 0.6))
 	provider.models_fetched.connect(
 		func(models: Array[String]): _on_models_fetched(provider_key, models),
 		CONNECT_ONE_SHOT
@@ -385,12 +516,18 @@ func _start_model_fetch(provider_key: String) -> void:
 func _on_models_fetched(provider_key: String, models: Array[String]) -> void:
 	var dropdown: OptionButton
 	var btn: Button
-	if provider_key == "anthropic":
-		dropdown = _anthropic_model_option
-		btn = _anthropic_refresh_btn
-	else:
-		dropdown = _openai_model_option
-		btn = _openai_refresh_btn
+	match provider_key:
+		"anthropic":
+			dropdown = _anthropic_model_option
+			btn = _anthropic_refresh_btn
+		"openai":
+			dropdown = _openai_model_option
+			btn = _openai_refresh_btn
+		"local":
+			dropdown = _local_model_option
+			btn = _local_refresh_btn
+		_:
+			return
 
 	# Preserve the current selection even if it isn't in the fetched list.
 	var current_model := ""
@@ -406,6 +543,66 @@ func _on_models_fetched(provider_key: String, models: Array[String]) -> void:
 	_populate_model_dropdown(dropdown, all_models, current_model)
 	btn.text = "Refresh"
 	btn.disabled = false
+	if provider_key == "local" and _local_status_label:
+		if not models.is_empty():
+			_local_status_label.text = "Connected"
+			_local_status_label.add_theme_color_override("font_color", Color(0.4, 0.8, 0.4))
+
+func _on_models_fetch_failed(provider_key: String, _error: String) -> void:
+	if provider_key != "local":
+		return
+	if _local_status_label:
+		_local_status_label.text = "Unreachable"
+		_local_status_label.add_theme_color_override("font_color", Color(0.9, 0.3, 0.3))
+	if _local_refresh_btn:
+		_local_refresh_btn.text = "Refresh"
+		_local_refresh_btn.disabled = false
+
+func _on_local_preset_selected(index: int) -> void:
+	if index < 0 or index >= LOCAL_PRESET_KEYS.size():
+		return
+	var key := LOCAL_PRESET_KEYS[index]
+	if _proxy_control_row:
+		_proxy_control_row.visible = (key == "claude_proxy")
+		if _proxy_control_row.visible:
+			_update_proxy_button_state()
+	var url: String = LOCAL_PRESETS[key]
+	if url.is_empty():
+		return  # "Custom" — leave URL field for manual editing
+	_local_endpoint_field.text = url
+	var local := _provider_manager.get_provider("local") if _provider_manager else null
+	if local:
+		local.set_endpoint_url(url)
+		local.clear_model_cache()
+		_start_model_fetch("local")
+
+# --- Claude Proxy controls ---
+
+func _on_proxy_toggle_pressed() -> void:
+	if _is_proxy_running_callable.is_valid() and _is_proxy_running_callable.call():
+		if _stop_proxy_callable.is_valid():
+			_stop_proxy_callable.call()
+		_update_proxy_button_state()
+	else:
+		var error: String = ""
+		if _start_proxy_callable.is_valid():
+			error = str(_start_proxy_callable.call())
+		if not error.is_empty():
+			_proxy_status_label.text = error
+			_proxy_status_label.add_theme_color_override("font_color", Color(0.9, 0.3, 0.3))
+			return
+		_update_proxy_button_state()
+		# Give the server a moment to start, then verify connection by fetching models.
+		get_tree().create_timer(1.5).timeout.connect(func(): _start_model_fetch("local"))
+
+func _update_proxy_button_state() -> void:
+	if not _proxy_toggle_btn or not _proxy_status_label:
+		return
+	var running: bool = _is_proxy_running_callable.is_valid() and _is_proxy_running_callable.call()
+	_proxy_toggle_btn.text = "Stop Proxy" if running else "Start Proxy"
+	_proxy_status_label.text = "Running" if running else "Stopped"
+	var color: Color = Color(0.4, 0.8, 0.4) if running else Color(0.6, 0.6, 0.6)
+	_proxy_status_label.add_theme_color_override("font_color", color)
 
 # --- Populate / Save ---
 
@@ -456,6 +653,25 @@ func _populate_fields() -> void:
 	_openrouter_temp_slider.value = _settings.openrouter_temperature
 	_openrouter_tokens_spin.value = _settings.openrouter_max_tokens
 
+	# Local
+	if _local_endpoint_field:
+		var preset_idx := LOCAL_PRESET_KEYS.find(_settings.local_server_preset)
+		if preset_idx < 0:
+			preset_idx = LOCAL_PRESET_KEYS.find("custom")
+		_local_preset_option.selected = preset_idx
+		var preset_key := LOCAL_PRESET_KEYS[preset_idx] if preset_idx >= 0 else "custom"
+		if _proxy_control_row:
+			_proxy_control_row.visible = (preset_key == "claude_proxy")
+			if _proxy_control_row.visible:
+				_update_proxy_button_state()
+		_local_endpoint_field.text = _settings.local_endpoint_url
+		_local_key_field.text = _settings.local_api_key
+		_local_temp_slider.value = _settings.local_temperature
+		_local_tokens_spin.value = _settings.local_max_tokens
+		if _provider_manager:
+			var local := _provider_manager.get_provider("local")
+			_populate_model_dropdown(_local_model_option, local.get_all_models(), _settings.local_model)
+
 func _set_dropdown_to(dropdown: OptionButton, value: String) -> void:
 	for i in dropdown.item_count:
 		if dropdown.get_item_text(i) == value:
@@ -490,6 +706,14 @@ func _on_save() -> void:
 	_settings.openrouter_temperature = _openrouter_temp_slider.value
 	_settings.openrouter_max_tokens = int(_openrouter_tokens_spin.value)
 
+	if _local_endpoint_field:
+		_settings.local_endpoint_url = _local_endpoint_field.text.strip_edges()
+		_settings.local_server_preset = LOCAL_PRESET_KEYS[_local_preset_option.selected] if _local_preset_option.selected >= 0 else "custom"
+		_settings.local_api_key = _local_key_field.text.strip_edges()
+		_settings.local_model = _local_model_option.get_item_text(_local_model_option.selected) if _local_model_option.item_count > 0 else ""
+		_settings.local_temperature = _local_temp_slider.value
+		_settings.local_max_tokens = int(_local_tokens_spin.value)
+
 	# Register custom models that are not in any provider's known list.
 	if _provider_manager:
 		var anthropic := _provider_manager.get_provider("anthropic")
@@ -506,6 +730,11 @@ func _on_save() -> void:
 		if not _settings.openrouter_model.is_empty() and \
 				not (_settings.openrouter_model in openrouter.get_available_models()):
 			_settings.add_custom_model("openrouter", _settings.openrouter_model)
+
+		var local := _provider_manager.get_provider("local")
+		if not _settings.local_model.is_empty() and \
+				not (_settings.local_model in local.get_available_models()):
+			_settings.add_custom_model("local", _settings.local_model)
 
 	# Save to disk immediately so settings survive an editor crash.
 	_settings.save()

--- a/addons/godot_ai/plugin.gd
+++ b/addons/godot_ai/plugin.gd
@@ -12,6 +12,7 @@ var _provider_manager: ProviderManager
 var _settings: AISettings
 var _parsed_focus_chat: Dictionary = {}
 var _parsed_send_code: Dictionary = {}
+var _proxy_pid: int = -1
 
 ## Initialize the plugin: create ProviderManager (must be in tree for HTTP),
 ## create ChatPanel with injected dependencies, connect settings_saved to
@@ -26,6 +27,7 @@ func _enter_tree() -> void:
 
 	_chat_panel = ChatPanel.new()
 	_chat_panel.setup(_provider_manager, _settings, get_editor_interface())
+	_chat_panel.set_proxy_controls(start_claude_proxy, stop_claude_proxy, is_claude_proxy_running)
 	_chat_panel.settings_saved.connect(_on_chat_settings_saved)
 
 	_chat_panel.name = PANEL_NAME
@@ -36,6 +38,7 @@ func _enter_tree() -> void:
 ## Teardown: save settings to disk (batched here instead of per-change),
 ## remove the dock panel, and free all nodes to avoid leaks.
 func _exit_tree() -> void:
+	stop_claude_proxy()
 	if _chat_panel:
 		remove_control_from_docks(_chat_panel)
 		_chat_panel.queue_free()
@@ -78,3 +81,41 @@ func _send_selected_code_to_chat() -> void:
 	if selected.is_empty():
 		return
 	_chat_panel.send_selected_code(selected)
+
+## Launches tools/claude_proxy.py as a background process.
+## Returns "" on success, or an error string on failure.
+func start_claude_proxy() -> String:
+	if _proxy_pid > 0:
+		return ""
+	var proxy_res_path: String = get_script().resource_path.get_base_dir().path_join("tools/claude_proxy.py")
+	var script_path := ProjectSettings.globalize_path(proxy_res_path)
+	if not FileAccess.file_exists(proxy_res_path):
+		return "Proxy script not found at " + proxy_res_path
+	var python_cmd := "python3"
+	if OS.get_name() == "Windows":
+		var output := []
+		var exit_code := OS.execute("where", PackedStringArray(["python3"]), output)
+		if exit_code != 0:
+			OS.execute("where", PackedStringArray(["python"]), output)
+			python_cmd = "python"
+	else:
+		var output := []
+		var exit_code := OS.execute("which", PackedStringArray(["python3"]), output)
+		if exit_code != 0:
+			return "python3 not found. Install Python 3 to use the built-in proxy."
+	var pid := OS.create_process(python_cmd, PackedStringArray([script_path]))
+	if pid <= 0:
+		return "Failed to start proxy process."
+	_proxy_pid = pid
+	return ""
+
+## Stops the running proxy process if one was started by the plugin.
+func stop_claude_proxy() -> void:
+	if _proxy_pid <= 0:
+		return
+	OS.kill(_proxy_pid)
+	_proxy_pid = -1
+
+## Returns true if the proxy was started by this plugin and has not been stopped.
+func is_claude_proxy_running() -> bool:
+	return _proxy_pid > 0

--- a/addons/godot_ai/providers/openai_compatible_provider.gd
+++ b/addons/godot_ai/providers/openai_compatible_provider.gd
@@ -1,0 +1,130 @@
+@tool
+class_name OpenAICompatibleProvider
+extends ProviderBase
+
+## OpenAI-compatible provider for local AI servers (Ollama, LM Studio, llama.cpp, vLLM).
+## All of these expose the same OpenAI chat completions wire format, so one class
+## handles all of them — the only difference is the base URL.
+##
+## Default endpoint: http://localhost:11434/v1 (Ollama)
+## No API key required for Ollama; optional for proxies that need one.
+
+const DEFAULT_ENDPOINT := "http://localhost:11434/v1"
+
+## Full base URL including scheme, host, port, and path prefix (e.g. "/v1").
+## Call set_endpoint_url() to update — it re-parses all components.
+var endpoint_url: String = DEFAULT_ENDPOINT
+
+var _parsed_host := "localhost"
+var _parsed_port := 11434
+var _parsed_use_ssl := false
+var _parsed_base_path := "/v1"
+
+func _init() -> void:
+	super()
+	model = "llama3.2"
+	_sse_client.set_provider("openai")  # OpenAI wire format
+	_parse_endpoint()
+
+func get_provider_name() -> String:
+	return "Local (Ollama / LM Studio)"
+
+## Update the endpoint URL and re-parse its components.
+func set_endpoint_url(url: String) -> void:
+	endpoint_url = url
+	_parse_endpoint()
+
+## Parse endpoint_url into host, port, ssl flag, and base path components.
+## Handles both http:// and https:// schemes, with or without explicit port numbers.
+func _parse_endpoint() -> void:
+	var url := endpoint_url.strip_edges()
+	if url.is_empty():
+		return
+
+	_parsed_use_ssl = url.begins_with("https://")
+	url = url.trim_prefix("https://").trim_prefix("http://")
+
+	# Split into host[:port] and /base_path
+	var slash_pos := url.find("/")
+	var host_port := url.left(slash_pos) if slash_pos != -1 else url
+	_parsed_base_path = url.substr(slash_pos) if slash_pos != -1 else ""
+
+	# Split host from optional port
+	var colon_pos := host_port.find(":")
+	if colon_pos != -1:
+		_parsed_host = host_port.left(colon_pos)
+		_parsed_port = int(host_port.substr(colon_pos + 1))
+	else:
+		_parsed_host = host_port
+		_parsed_port = 443 if _parsed_use_ssl else 80
+
+func get_api_host() -> String:
+	return _parsed_host
+
+func get_api_path() -> String:
+	return _parsed_base_path + "/chat/completions"
+
+func get_api_port() -> int:
+	return _parsed_port
+
+func get_api_use_ssl() -> bool:
+	return _parsed_use_ssl
+
+## Local providers require a valid endpoint URL, not an API key.
+## Ollama needs no key; api_key is only used when a proxy requires one.
+func is_configured() -> bool:
+	return not endpoint_url.is_empty()
+
+## No hardcoded fallback — only show models actually fetched from the local server.
+func get_available_models() -> Array[String]:
+	return []
+
+## Path for listing installed models. Appended to base path so it resolves correctly
+## regardless of the configured endpoint prefix (e.g. /v1/models).
+func _get_models_path() -> String:
+	return _parsed_base_path + "/models"
+
+## Parse the models list response. Handles both OpenAI-compat format
+## ({"data": [{id: "..."}]}) and Ollama native format ({"models": [{model: "..."}]}).
+func _parse_models_response(json: Dictionary) -> Array[String]:
+	var result: Array[String] = []
+
+	# OpenAI-compat: {"data": [{id: "model-name"}, ...]}
+	var data = json.get("data", [])
+	if data is Array and not data.is_empty():
+		for item in data:
+			if item is Dictionary and item.has("id"):
+				result.append(str(item["id"]))
+
+	# Ollama native: {"models": [{model: "name:tag"}, ...]}
+	if result.is_empty():
+		var models = json.get("models", [])
+		if models is Array:
+			for item in models:
+				if item is Dictionary:
+					var id: String = str(item.get("model", item.get("name", "")))
+					if not id.is_empty():
+						result.append(id)
+
+	result.sort()
+	return result
+
+func _build_request_body(messages: Array, system_prompt: String) -> Dictionary:
+	var full_messages: Array = []
+	if not system_prompt.is_empty():
+		full_messages.append({"role": "system", "content": system_prompt})
+	full_messages.append_array(messages)
+	return {
+		"model": model,
+		"max_tokens": max_tokens,
+		"temperature": temperature,
+		"stream": true,
+		"messages": full_messages,
+	}
+
+func _build_headers() -> PackedStringArray:
+	var headers := PackedStringArray(["Content-Type: application/json"])
+	# API key is optional — only add if the user configured one (e.g. for a proxy).
+	if not api_key.is_empty():
+		headers.append("Authorization: Bearer " + api_key)
+	return headers

--- a/addons/godot_ai/providers/provider_base.gd
+++ b/addons/godot_ai/providers/provider_base.gd
@@ -58,7 +58,7 @@ func send_message(messages: Array, system_prompt: String = "") -> void:
 	var headers := _build_headers()
 
 	_setup_stream()
-	_http_stream.send_request(get_api_host(), get_api_path(), headers, body_json)
+	_http_stream.send_request(get_api_host(), get_api_path(), headers, body_json, get_api_port(), get_api_use_ssl())
 
 ## Cancel an in-progress request.
 func cancel() -> void:
@@ -101,7 +101,11 @@ func fetch_models() -> void:
 	_models_http_request = HTTPRequest.new()
 	_parent_node.add_child(_models_http_request)
 	_models_http_request.request_completed.connect(_on_models_response)
-	var url := "https://" + get_api_host() + path
+	var scheme := "https" if get_api_use_ssl() else "http"
+	var port := get_api_port()
+	var default_port := 443 if get_api_use_ssl() else 80
+	var host_part := get_api_host() if port == default_port else "%s:%d" % [get_api_host(), port]
+	var url := "%s://%s%s" % [scheme, host_part, path]
 	_models_http_request.request(url, _build_headers(), HTTPClient.METHOD_GET)
 
 ## Clear the cached model list so the next fetch_models() hits the API.
@@ -140,6 +144,14 @@ func get_api_host() -> String:
 func get_api_path() -> String:
 	push_error("ProviderBase.get_api_path() not implemented")
 	return ""
+
+## Return the TCP port to connect on. Default 443 (HTTPS). Override for local servers.
+func get_api_port() -> int:
+	return 443
+
+## Return whether to use TLS. Default true. Override to false for local HTTP servers.
+func get_api_use_ssl() -> bool:
+	return true
 
 ## Build the JSON-serialisable request body dict for this provider.
 func _build_request_body(_messages: Array, _system_prompt: String) -> Dictionary:
@@ -225,7 +237,12 @@ func _on_models_response(result: int, response_code: int, _headers: PackedString
 		_models_http_request = null
 
 	if result != HTTPRequest.RESULT_SUCCESS or response_code != 200:
-		models_fetch_failed.emit("HTTP error %d" % response_code)
+		var msg: String
+		if result != HTTPRequest.RESULT_SUCCESS:
+			msg = "Could not connect to server"
+		else:
+			msg = "Server returned HTTP %d" % response_code
+		models_fetch_failed.emit(msg)
 		models_fetched.emit(get_available_models())
 		return
 

--- a/addons/godot_ai/providers/provider_manager.gd
+++ b/addons/godot_ai/providers/provider_manager.gd
@@ -9,8 +9,10 @@ extends Node
 signal response_token(text: String)
 signal response_completed(full_text: String)
 signal response_error(error: String)
+signal models_updated(provider_key: String)
+signal models_fetch_failed(provider_key: String, error: String)
 
-const PROVIDER_KEYS: Array[String] = ["anthropic", "openai", "openrouter"]
+const PROVIDER_KEYS: Array[String] = ["anthropic", "openai", "openrouter", "local"]
 
 var _providers: Dictionary = {}   # String -> ProviderBase
 var _active_provider_name := "anthropic"
@@ -21,6 +23,16 @@ func _init() -> void:
 	_providers["anthropic"] = AnthropicProvider.new()
 	_providers["openai"] = OpenAIProvider.new()
 	_providers["openrouter"] = OpenRouterProvider.new()
+	_providers["local"] = OpenAICompatibleProvider.new()
+	for key in _providers:
+		_providers[key].models_fetched.connect(_on_provider_models_fetched.bind(key))
+		_providers[key].models_fetch_failed.connect(_on_provider_models_fetch_failed.bind(key))
+
+func _on_provider_models_fetched(_models: Array[String], provider_key: String) -> void:
+	models_updated.emit(provider_key)
+
+func _on_provider_models_fetch_failed(error: String, provider_key: String) -> void:
+	models_fetch_failed.emit(provider_key, error)
 
 ## Registers all providers as children so their HTTPStream nodes can use the
 ## scene tree, then restores settings if the plugin reloads mid-session.
@@ -94,6 +106,14 @@ func apply_settings(settings: AISettings) -> void:
 	openrouter.temperature = settings.openrouter_temperature
 	openrouter.max_tokens = settings.openrouter_max_tokens
 	openrouter.set_custom_models(settings.custom_models.get("openrouter", []))
+
+	var local: OpenAICompatibleProvider = _providers["local"]
+	local.set_endpoint_url(settings.local_endpoint_url)
+	local.api_key = settings.local_api_key
+	local.model = settings.local_model
+	local.temperature = settings.local_temperature
+	local.max_tokens = settings.local_max_tokens
+	local.set_custom_models(settings.custom_models.get("local", []))
 
 ## Forward a chat request to the active provider after a basic guard check.
 func send_message(messages: Array, system_prompt: String = "") -> void:

--- a/addons/godot_ai/streaming/http_stream.gd
+++ b/addons/godot_ai/streaming/http_stream.gd
@@ -41,7 +41,8 @@ var _elapsed := 0.0
 ## Uses low-level HTTPClient (not HTTPRequest) so the response body can be
 ## read chunk-by-chunk via _process() as it arrives, rather than waiting for
 ## the full response — essential for streaming LLM responses.
-func send_request(host: String, path: String, headers: PackedStringArray, body: String) -> void:
+## port defaults to 443 for HTTPS, 80 for HTTP; use_ssl defaults to true.
+func send_request(host: String, path: String, headers: PackedStringArray, body: String, port: int = -1, use_ssl: bool = true) -> void:
 	if _state != State.IDLE and _state != State.DONE and _state != State.ERROR:
 		push_warning("HTTPStream: request already in progress")
 		return
@@ -57,10 +58,11 @@ func send_request(host: String, path: String, headers: PackedStringArray, body: 
 	_state = State.CONNECTING
 
 	_client = HTTPClient.new()
-	_use_ssl = true
-	_port = 443
+	_use_ssl = use_ssl
+	_port = port if port != -1 else (443 if use_ssl else 80)
 
-	var err := _client.connect_to_host(_host, _port, TLSOptions.client())
+	var tls_options := TLSOptions.client() if _use_ssl else null
+	var err := _client.connect_to_host(_host, _port, tls_options)
 	if err != OK:
 		_state = State.ERROR
 		request_failed.emit("Failed to connect: %s" % error_string(err))
@@ -142,7 +144,7 @@ func _process(delta: float) -> void:
 								_response_body.append_array(chunk)
 							else:
 								chunk_received.emit(chunk.get_string_from_utf8())
-				HTTPClient.STATUS_CONNECTED, HTTPClient.STATUS_DISCONNECTED:
+				HTTPClient.STATUS_CONNECTED, HTTPClient.STATUS_DISCONNECTED, HTTPClient.STATUS_CONNECTION_ERROR:
 					_state = State.DONE
 					_client.close()
 					if _error_reading:

--- a/addons/godot_ai/tools/claude_proxy.py
+++ b/addons/godot_ai/tools/claude_proxy.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+"""
+claude_proxy.py — OpenAI-compatible HTTP proxy for the Claude Code CLI.
+
+Routes /v1/chat/completions requests through the local `claude` CLI so that
+GodotAI (and other OpenAI-compatible clients) can use a Claude Pro/Max
+subscription without needing a separate Anthropic API key.
+
+Usage:
+    python3 tools/claude_proxy.py [--port 8082] [--host 0.0.0.0] [--verbose]
+
+Then in GodotAI Settings → Local tab, select "Claude Proxy" preset.
+"""
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import time
+import uuid
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from socketserver import ThreadingMixIn
+
+# ---------------------------------------------------------------------------
+# Available models (static list returned by GET /v1/models)
+# ---------------------------------------------------------------------------
+CLAUDE_MODELS = [
+    "claude-opus-4-6",
+    "claude-sonnet-4-6",
+    "claude-haiku-4-5",
+    "opus",
+    "sonnet",
+    "haiku",
+]
+
+VERBOSE = False
+
+
+def log(msg: str) -> None:
+    if VERBOSE:
+        print(msg, file=sys.stderr, flush=True)
+
+
+# ---------------------------------------------------------------------------
+# Message formatting
+# ---------------------------------------------------------------------------
+
+def format_messages(messages: list) -> tuple[str, str]:
+    """
+    Flatten an OpenAI messages array into (system_prompt, conversation_prompt).
+
+    System messages are joined and passed via --system-prompt.
+    User/assistant turns are formatted as Human:/Assistant: pairs so Claude
+    understands the conversation history.
+    """
+    system_parts = []
+    conversation_parts = []
+
+    for msg in messages:
+        role = msg.get("role", "")
+        content = msg.get("content", "")
+        if isinstance(content, list):
+            # Handle content arrays (e.g. image + text) — extract text parts only
+            content = " ".join(
+                part.get("text", "") for part in content if part.get("type") == "text"
+            )
+        if role == "system":
+            system_parts.append(content)
+        elif role == "user":
+            conversation_parts.append(f"Human: {content}")
+        elif role == "assistant":
+            conversation_parts.append(f"Assistant: {content}")
+
+    system_prompt = "\n".join(system_parts)
+    prompt = "\n\n".join(conversation_parts)
+    return system_prompt, prompt
+
+
+# ---------------------------------------------------------------------------
+# OpenAI SSE chunk helpers
+# ---------------------------------------------------------------------------
+
+def make_chunk(text: str, model: str, chunk_id: str, finish_reason=None) -> str:
+    """Serialise one OpenAI-format SSE data line."""
+    payload = {
+        "id": chunk_id,
+        "object": "chat.completion.chunk",
+        "created": int(time.time()),
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "delta": {"content": text} if text else {},
+                "finish_reason": finish_reason,
+            }
+        ],
+    }
+    return f"data: {json.dumps(payload)}\n\n"
+
+
+def make_error_response(code: int, message: str) -> bytes:
+    body = json.dumps({"error": {"message": message, "type": "server_error"}})
+    return body.encode()
+
+
+# ---------------------------------------------------------------------------
+# Claude CLI invocation
+# ---------------------------------------------------------------------------
+
+def call_claude(prompt: str, system_prompt: str, model: str) -> str:
+    """
+    Run `claude --print --bare --output-format json` and return the response text.
+    Raises RuntimeError on failure.
+    """
+    cmd = [
+        "claude",
+        "--print",
+        "--output-format", "json",
+        "--model", model,
+    ]
+    if system_prompt:
+        cmd += ["--system-prompt", system_prompt]
+    cmd.append(prompt)
+
+    log(f"[claude] running: claude --print --bare --output-format json --model {model} ...")
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    except FileNotFoundError:
+        raise RuntimeError("'claude' command not found. Install Claude Code: https://claude.ai/code")
+    except subprocess.TimeoutExpired:
+        raise RuntimeError("Claude CLI timed out after 120 seconds.")
+
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
+        stdout = result.stdout.strip()
+        raise RuntimeError(stderr or stdout or f"claude exited with code {result.returncode}")
+
+    raw = result.stdout.strip()
+    log(f"[claude] raw output: {raw[:200]}...")
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        # Plain text fallback (shouldn't happen with --output-format json)
+        return raw
+
+    if data.get("is_error"):
+        raise RuntimeError(data.get("result", "Unknown error from Claude CLI"))
+
+    return data.get("result", "")
+
+
+# ---------------------------------------------------------------------------
+# HTTP request handler
+# ---------------------------------------------------------------------------
+
+class ProxyHandler(BaseHTTPRequestHandler):
+    """Handles GET /v1/models and POST /v1/chat/completions."""
+
+    def log_message(self, fmt, *args):  # noqa: N802
+        if VERBOSE:
+            super().log_message(fmt, *args)
+
+    # ------------------------------------------------------------------
+    # Routing
+    # ------------------------------------------------------------------
+
+    def do_GET(self):  # noqa: N802
+        if self.path == "/v1/models":
+            self._handle_models()
+        else:
+            self._send_json(404, {"error": {"message": f"Unknown path: {self.path}"}})
+
+    def do_POST(self):  # noqa: N802
+        if self.path == "/v1/chat/completions":
+            self._handle_chat_completions()
+        else:
+            self._send_json(404, {"error": {"message": f"Unknown path: {self.path}"}})
+
+    # ------------------------------------------------------------------
+    # GET /v1/models
+    # ------------------------------------------------------------------
+
+    def _handle_models(self):
+        body = {
+            "object": "list",
+            "data": [
+                {"id": m, "object": "model", "owned_by": "anthropic"}
+                for m in CLAUDE_MODELS
+            ],
+        }
+        self._send_json(200, body)
+
+    # ------------------------------------------------------------------
+    # POST /v1/chat/completions
+    # ------------------------------------------------------------------
+
+    def _handle_chat_completions(self):
+        length = int(self.headers.get("Content-Length", 0))
+        raw_body = self.rfile.read(length)
+        try:
+            body = json.loads(raw_body)
+        except json.JSONDecodeError:
+            self._send_error(400, "Invalid JSON body")
+            return
+
+        messages = body.get("messages", [])
+        model = body.get("model", "sonnet")
+        stream = body.get("stream", True)
+
+        if not messages:
+            self._send_error(400, "No messages provided")
+            return
+
+        system_prompt, prompt = format_messages(messages)
+        log(f"[request] model={model} stream={stream} prompt_len={len(prompt)}")
+
+        # Tell Python's HTTP server not to attempt another keep-alive request
+        # after this response — the streaming response closes the connection.
+        self.close_connection = True
+
+        try:
+            response_text = call_claude(prompt, system_prompt, model)
+        except RuntimeError as err:
+            self._send_error(502, str(err))
+            return
+
+        log(f"[response] text_len={len(response_text)}")
+
+        if stream:
+            self._stream_response(response_text, model)
+        else:
+            self._json_response(response_text, model)
+
+    # ------------------------------------------------------------------
+    # Response writers
+    # ------------------------------------------------------------------
+
+    def _stream_response(self, text: str, model: str):
+        """Emit text as OpenAI SSE chunks.
+
+        The proxy buffers the complete SSE body before sending so that a
+        Content-Length header can be included.  Without it, Godot's HTTPClient
+        skips STATUS_BODY entirely (no body framing → no readable chunks).
+        """
+        chunk_id = f"chatcmpl-{uuid.uuid4().hex[:12]}"
+
+        # Split into words, preserving surrounding whitespace
+        words = []
+        current = ""
+        for ch in text:
+            current += ch
+            if ch in (" ", "\n", "\t"):
+                words.append(current)
+                current = ""
+        if current:
+            words.append(current)
+
+        parts = [make_chunk(w, model, chunk_id).encode() for w in words]
+        parts.append(make_chunk("", model, chunk_id, finish_reason="stop").encode())
+        parts.append(b"data: [DONE]\n\n")
+        body = b"".join(parts)
+
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Connection", "close")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+
+        try:
+            self.wfile.write(body)
+            self.wfile.flush()
+        except (BrokenPipeError, ConnectionResetError):
+            log("[stream] client disconnected")
+
+    def _json_response(self, text: str, model: str):
+        """Return a single non-streaming OpenAI completion response."""
+        body = {
+            "id": f"chatcmpl-{uuid.uuid4().hex[:12]}",
+            "object": "chat.completion",
+            "created": int(time.time()),
+            "model": model,
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": text},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+        }
+        self._send_json(200, body)
+
+    def _send_json(self, code: int, data: dict):
+        body = json.dumps(data).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_error(self, code: int, message: str):
+        self._send_json(code, {"error": {"message": message, "type": "server_error"}})
+
+
+# ---------------------------------------------------------------------------
+# Threaded server
+# ---------------------------------------------------------------------------
+
+class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
+    """Handle each request in its own thread so model fetches don't block chat."""
+    daemon_threads = True
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main():
+    global VERBOSE
+
+    parser = argparse.ArgumentParser(
+        description="OpenAI-compatible proxy for the Claude Code CLI."
+    )
+    parser.add_argument("--port", type=int, default=8082, help="Port to listen on (default: 8082)")
+    parser.add_argument("--host", default="127.0.0.1", help="Host to bind to (default: 127.0.0.1)")
+    parser.add_argument("--verbose", action="store_true", help="Log requests and responses to stderr")
+    args = parser.parse_args()
+
+    VERBOSE = args.verbose
+
+    # Verify claude CLI is available before starting
+    claude_path = shutil.which("claude")
+    if not claude_path:
+        print(
+            "ERROR: 'claude' command not found.\n"
+            "Install Claude Code from https://claude.ai/code and sign in with `claude auth`.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    print(f"Claude CLI found: {claude_path}")
+    print(f"Starting proxy on http://{args.host}:{args.port}")
+    print("Press Ctrl+C to stop.\n")
+
+    server = ThreadedHTTPServer((args.host, args.port), ProxyHandler)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nProxy stopped.")
+
+
+if __name__ == "__main__":
+    main()

--- a/addons/godot_ai/ui/chat_panel.gd
+++ b/addons/godot_ai/ui/chat_panel.gd
@@ -14,6 +14,9 @@ var _provider_manager: ProviderManager = null
 var _settings: AISettings = null
 var _settings_dialog: AISettingsDialog = null
 var _editor_interface: EditorInterface = null
+var _start_proxy_callable: Callable
+var _stop_proxy_callable: Callable
+var _is_proxy_running_callable: Callable
 
 # Chat state
 var _messages: Array = []  # Array of {role, content}
@@ -47,8 +50,21 @@ func setup(provider_manager: ProviderManager, settings: AISettings, editor_inter
 	_provider_manager.response_token.connect(_on_token)
 	_provider_manager.response_completed.connect(_on_completed)
 	_provider_manager.response_error.connect(_on_error)
+	_provider_manager.models_updated.connect(_on_provider_models_updated)
+	_provider_manager.models_fetch_failed.connect(_on_models_fetch_failed)
+
+	# Auto-fetch local models — local is always "configured" (just needs an endpoint URL).
+	var local_provider := _provider_manager.get_provider("local")
+	if local_provider and local_provider.is_configured() and not local_provider.has_cached_models():
+		local_provider.fetch_models()
 
 	_refresh_provider_ui()
+
+## Pass proxy control callables from plugin.gd to be forwarded to the settings dialog.
+func set_proxy_controls(start_fn: Callable, stop_fn: Callable, is_running_fn: Callable) -> void:
+	_start_proxy_callable = start_fn
+	_stop_proxy_callable = stop_fn
+	_is_proxy_running_callable = is_running_fn
 
 func _ready() -> void:
 	_build_ui()
@@ -105,6 +121,7 @@ func _build_ui() -> void:
 	_provider_option.add_item("Anthropic", 0)
 	_provider_option.add_item("OpenAI", 1)
 	_provider_option.add_item("OpenRouter", 2)
+	_provider_option.add_item("Local (Ollama / LM Studio)", 3)
 	_provider_option.item_selected.connect(_on_provider_changed)
 	provider_row.add_child(_provider_option)
 
@@ -189,6 +206,10 @@ func _exit_tree() -> void:
 			_provider_manager.response_completed.disconnect(_on_completed)
 		if _provider_manager.response_error.is_connected(_on_error):
 			_provider_manager.response_error.disconnect(_on_error)
+		if _provider_manager.models_updated.is_connected(_on_provider_models_updated):
+			_provider_manager.models_updated.disconnect(_on_provider_models_updated)
+		if _provider_manager.models_fetch_failed.is_connected(_on_models_fetch_failed):
+			_provider_manager.models_fetch_failed.disconnect(_on_models_fetch_failed)
 	if _settings_dialog:
 		_settings_dialog.queue_free()
 		_settings_dialog = null
@@ -335,6 +356,7 @@ func _on_error(error: String) -> void:
 		_messages.pop_back()
 	_set_waiting(false)
 	_set_status("Error")
+	_scroll_to_bottom()
 
 ## Stop the active stream and roll back any partial state: finishes the
 ## assistant bubble (if any) and removes the unanswered user message.
@@ -349,6 +371,7 @@ func _on_cancel_pressed() -> void:
 	if not _messages.is_empty() and _messages.back().get("role") == "user":
 		_messages.pop_back()
 	_set_waiting(false)
+	_scroll_to_bottom()
 
 func _on_clear_pressed() -> void:
 	_stop_thinking_indicator()
@@ -367,6 +390,7 @@ func _on_settings_pressed() -> void:
 		add_child(_settings_dialog)
 		_settings_dialog.settings_saved.connect(_on_settings_saved)
 		_settings_dialog.setup_provider_manager(_provider_manager)
+		_settings_dialog.set_proxy_controls(_start_proxy_callable, _stop_proxy_callable, _is_proxy_running_callable)
 	_settings_dialog.open_with_settings(_settings)
 
 ## Apply new settings and propagate font size to all existing message widgets,
@@ -387,6 +411,24 @@ func _on_provider_changed(index: int) -> void:
 	if _provider_manager:
 		_provider_manager.set_active_provider(ProviderManager.PROVIDER_KEYS[index])
 	_refresh_model_dropdown()
+	# Trigger health check when switching to local provider
+	if _provider_manager and ProviderManager.PROVIDER_KEYS[index] == "local":
+		var local := _provider_manager.get_provider("local")
+		if local and local.is_configured() and not local.has_cached_models():
+			local.fetch_models()
+
+func _on_models_fetch_failed(provider_key: String, error: String) -> void:
+	if provider_key != _provider_manager.get_active_provider_name():
+		return
+	if provider_key == "local":
+		_set_status("Local server unreachable")
+		var error_display := MessageDisplay.create_assistant_placeholder(_get_editor_font_size())
+		error_display.append_token(
+			"[Error: Local server unreachable]\n%s\n\nMake sure Ollama is running (ollama serve) and the endpoint URL is correct in Settings." % error
+		)
+		error_display.finish_streaming()
+		_add_message_to_list(error_display, MessageDisplay.Role.ASSISTANT)
+		_scroll_to_bottom()
 
 func _on_model_changed(index: int) -> void:
 	if not _provider_manager:
@@ -431,6 +473,10 @@ func _refresh_model_dropdown() -> void:
 	if not found and not provider.model.is_empty():
 		_model_option.add_item(provider.model)
 		_model_option.selected = _model_option.item_count - 1
+
+func _on_provider_models_updated(provider_key: String) -> void:
+	if provider_key == _provider_manager.get_active_provider_name():
+		_refresh_model_dropdown()
 
 func _set_waiting(waiting: bool) -> void:
 	_is_waiting = waiting
@@ -485,6 +531,7 @@ func _load_history() -> void:
 		return
 	_messages = parsed
 	_restore_messages_ui()
+	_scroll_to_bottom()
 
 ## Rebuild the UI from saved history. Unlike the live streaming path, this
 ## renders complete messages directly through MarkdownParser (no token-by-token).
@@ -526,9 +573,10 @@ func send_selected_code(code: String) -> void:
 	_input_field.set_caret_column(0)
 	_input_field.grab_focus()
 
-## Scroll to the bottom after one frame — layout hasn't been computed yet
+## Scroll to the bottom after two frames — layout hasn't been computed yet
 ## at call time, so we wait for the engine to resolve sizes.
 func _scroll_to_bottom() -> void:
+	await get_tree().process_frame
 	await get_tree().process_frame
 	if _scroll_container:
 		_scroll_container.scroll_vertical = _scroll_container.get_v_scroll_bar().max_value

--- a/addons/godot_ai/ui/message_display.gd
+++ b/addons/godot_ai/ui/message_display.gd
@@ -39,6 +39,8 @@ static func create_assistant_placeholder(font_size: int = 28) -> MessageDisplay:
 	msg._font_size = font_size
 	msg._is_streaming = true
 	msg._streaming_text = ""
+	var header := msg._make_role_header("Assistant")
+	msg.add_child(header)
 	msg._streaming_label = msg._make_rich_label()
 	msg.add_child(msg._streaming_label)
 	return msg
@@ -66,10 +68,10 @@ func finish_streaming() -> void:
 	_is_streaming = false
 	_full_text = _streaming_text
 
-	# Re-render with full parse (extracts code blocks)
-	if _streaming_label and is_instance_valid(_streaming_label):
-		_streaming_label.queue_free()
-		_streaming_label = null
+	# Clear all children (header + streaming label) before full re-render
+	for child in get_children():
+		child.queue_free()
+	_streaming_label = null
 
 	_render_assistant_message(_full_text)
 


### PR DESCRIPTION
## Summary
- Add OpenAI-compatible provider for Ollama, LM Studio, llama.cpp, and any compatible local server
- Add built-in Claude CLI proxy so users with Claude Pro/Max can avoid API billing
- Update settings dialog with Local tab: server presets, connection status, model refresh, proxy Start/Stop
- Update HTTP stream to support non-TLS connections on custom ports
- Add OLLAMA_SETUP.md and CLAUDE_PROXY_SETUP.md setup guides
- Update README with local model quick-start documentation

## Test plan
- [ ] Enable plugin in Godot editor — settings dialog shows a "Local" tab with server presets
- [ ] Test Ollama connection: select Ollama preset, click Refresh, models populate, send a message
- [ ] Test Claude Proxy: select Claude Proxy preset, click Start, status shows Running, send a message
- [ ] Verify existing Anthropic, OpenAI, and OpenRouter providers still work correctly
- [ ] Verify error state when local server is unreachable (red status + helpful chat message)
- [ ] Verify chat history persists across editor restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)